### PR TITLE
Stream-all Node

### DIFF
--- a/loxone/loxone.html
+++ b/loxone/loxone.html
@@ -943,3 +943,60 @@
 </script>
 
 
+<script type="text/x-red" data-help-name="loxone-stream-all">
+    <p>
+        This node will stream all events from the Loxone Server<br>
+    </p>
+</script>
+
+<script type="text/x-red" data-template-name="loxone-stream-all">
+
+    <div class="form-row">
+        <label for="node-input-miniserver">
+            <i class="fa fa-globe"></i>
+            Miniserver
+        </label>
+        <input type="text" id="node-input-miniserver">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+
+    <div class="form-row">
+        <span id="return-msg"></span>
+    </div>
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('loxone-stream-all', {
+        category: 'loxone',
+        paletteLabel: 'stream all',
+        color: '#83B817',
+        defaults: {
+            name: {value: ''},
+            miniserver: {type: 'loxone-miniserver', required: true},
+        },
+        inputs: 0,
+        outputs: 1,
+        icon: "loxone.png",
+        align: "left",
+        label: function () {
+            return this.name || "stream all";
+        },
+        oneditprepare: function () {
+            var node = this;
+
+            function prepareInput() {
+                disableChangeEvents();
+                $('#node-input-miniserver').on('change', prepareInput);
+            }
+
+            prepareInput();
+        },
+        oneditsave: disableChangeEvents,
+        oneditcancel: disableChangeEvents
+    });
+</script>
+

--- a/loxone/loxone.js
+++ b/loxone/loxone.js
@@ -476,7 +476,7 @@ module.exports = function (RED) {
                     this._inputNodes[i].send(this.buildMsgObject(event, uuid, controlStructure));
                 }
             }
-            console.log(this._streamAllNodes.length);
+
             for (i = 0; i < this._streamAllNodes.length; i++) {
                 curNode = this._streamAllNodes[i];
                 try {


### PR DESCRIPTION
I added a Node that streams all events. I think this is very interesting for example when you want
to publish all data from the loxone over mqtt. Maybe the comments for the Node must be completed. It would be great if you can add the uuid from the event to the output. So the receiver side has a unique assignment of the received event.  